### PR TITLE
Windows compatibility.

### DIFF
--- a/classes/GitUpdate.php
+++ b/classes/GitUpdate.php
@@ -872,6 +872,7 @@ class GitUpdate
         $adminDir = false;
         if (defined('_PS_ADMIN_DIR_')) {
             $adminDir = str_replace(_PS_ROOT_DIR_, '', _PS_ADMIN_DIR_);
+            $adminDir = str_replace('\\', '/', $adminDir);
             $adminDir = trim($adminDir, '/').'/';
         }
 


### PR DESCRIPTION
#9 tells about two places with Windows path separators in $adminDir. 454 was fixed in a9abf97 but 874 is not.