### PR TITLE
Ignore files and preview diffrences functions during update (developer mode ON only)

### DIFF
--- a/classes/Factory.php
+++ b/classes/Factory.php
@@ -38,6 +38,7 @@ require_once __DIR__.'/storage/Storage.php';
 require_once __DIR__.'/storage/StorageFactory.php';
 require_once __DIR__.'/storage/StorageDb.php';
 require_once __DIR__.'/storage/StorageFilesystem.php';
+require_once __DIR__.'/MergeService.php';
 require_once __DIR__.'/Utils.php';
 require_once __DIR__.'/Settings.php';
 require_once __DIR__.'/Retrocompatibility.php';

--- a/classes/MergeService.php
+++ b/classes/MergeService.php
@@ -1,0 +1,742 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+namespace CoreUpdater;
+
+class MergeService
+{
+    const MATRIX_FALLBACK_LIMIT = 120;
+
+    /**
+     * Build a three-way, line-based merge preview for text content.
+     *
+     * @param string $baseContent
+     * @param string $localContent
+     * @param string $incomingContent
+     *
+     * @return array
+     */
+    public static function buildMergePreview($baseContent, $localContent, $incomingContent)
+    {
+        $lineEnding = static::detectLineEnding($localContent, $incomingContent, $baseContent);
+        $base = static::splitLines($baseContent);
+        $local = static::splitLines($localContent);
+        $incoming = static::splitLines($incomingContent);
+
+        $localChanges = static::buildChanges($base, $local);
+        $incomingChanges = static::buildChanges($base, $incoming);
+
+        $chunks = [];
+        $merged = [];
+        $choiceCount = 0;
+        $conflictCount = 0;
+        $position = 0;
+        $localIndex = 0;
+        $incomingIndex = 0;
+        $chunkId = 1;
+
+        while ($localIndex < count($localChanges) || $incomingIndex < count($incomingChanges)) {
+            $localChange = $localIndex < count($localChanges) ? $localChanges[$localIndex] : null;
+            $incomingChange = $incomingIndex < count($incomingChanges) ? $incomingChanges[$incomingIndex] : null;
+
+            if ($localChange && (! $incomingChange || (! static::changesOverlap($localChange, $incomingChange) && static::changeBefore($localChange, $incomingChange)))) {
+                static::appendContextChunk($chunks, $merged, $base, $position, $localChange['start']);
+                $localVariant = static::applyChanges($base, $localChange['start'], $localChange['end'], [$localChange]);
+                $incomingVariant = array_slice($base, $localChange['start'], $localChange['end'] - $localChange['start']);
+                static::appendChoiceChunk($chunks, $merged, [
+                    'id' => 'chunk-' . $chunkId++,
+                    'state' => 'local',
+                    'base' => $incomingVariant,
+                    'local' => $localVariant,
+                    'incoming' => $incomingVariant,
+                    'defaultChoice' => 'incoming',
+                ]);
+                $choiceCount++;
+                $position = $localChange['end'];
+                $localIndex++;
+                continue;
+            }
+
+            if ($incomingChange && (! $localChange || (! static::changesOverlap($incomingChange, $localChange) && static::changeBefore($incomingChange, $localChange)))) {
+                static::appendContextChunk($chunks, $merged, $base, $position, $incomingChange['start']);
+                $baseVariant = array_slice($base, $incomingChange['start'], $incomingChange['end'] - $incomingChange['start']);
+                $incomingVariant = static::applyChanges($base, $incomingChange['start'], $incomingChange['end'], [$incomingChange]);
+                static::appendChoiceChunk($chunks, $merged, [
+                    'id' => 'chunk-' . $chunkId++,
+                    'state' => 'incoming',
+                    'base' => $baseVariant,
+                    'local' => $baseVariant,
+                    'incoming' => $incomingVariant,
+                    'defaultChoice' => 'incoming',
+                ]);
+                $choiceCount++;
+                $position = $incomingChange['end'];
+                $incomingIndex++;
+                continue;
+            }
+
+            $groupStart = min($localChange['start'], $incomingChange['start']);
+            $groupEnd = max($localChange['end'], $incomingChange['end']);
+            $localGroup = [$localChange];
+            $incomingGroup = [$incomingChange];
+            $localIndex++;
+            $incomingIndex++;
+
+            $expanded = true;
+            while ($expanded) {
+                $expanded = false;
+
+                while ($localIndex < count($localChanges) && static::changeTouchesSpan($localChanges[$localIndex], $groupStart, $groupEnd)) {
+                    $localGroup[] = $localChanges[$localIndex];
+                    $groupEnd = max($groupEnd, $localChanges[$localIndex]['end']);
+                    $localIndex++;
+                    $expanded = true;
+                }
+
+                while ($incomingIndex < count($incomingChanges) && static::changeTouchesSpan($incomingChanges[$incomingIndex], $groupStart, $groupEnd)) {
+                    $incomingGroup[] = $incomingChanges[$incomingIndex];
+                    $groupEnd = max($groupEnd, $incomingChanges[$incomingIndex]['end']);
+                    $incomingIndex++;
+                    $expanded = true;
+                }
+            }
+
+            static::appendContextChunk($chunks, $merged, $base, $position, $groupStart);
+
+            $baseVariant = array_slice($base, $groupStart, $groupEnd - $groupStart);
+            $localVariant = static::applyChanges($base, $groupStart, $groupEnd, $localGroup);
+            $incomingVariant = static::applyChanges($base, $groupStart, $groupEnd, $incomingGroup);
+
+            if ($localVariant === $incomingVariant) {
+                $chunks[] = [
+                    'type' => 'choice',
+                    'id' => 'chunk-' . $chunkId++,
+                    'state' => 'same',
+                    'defaultChoice' => 'incoming',
+                    'content' => base64_encode(static::joinLines($incomingVariant, "\n")),
+                    'base' => base64_encode(static::joinLines($baseVariant, "\n")),
+                    'local' => base64_encode(static::joinLines($localVariant, "\n")),
+                    'incoming' => base64_encode(static::joinLines($incomingVariant, "\n")),
+                ];
+                $merged = array_merge($merged, $incomingVariant);
+            } else {
+                $state = 'conflict';
+                if ($localVariant === $baseVariant) {
+                    $state = 'incoming';
+                } elseif ($incomingVariant === $baseVariant) {
+                    $state = 'local';
+                } else {
+                    $conflictCount++;
+                }
+                static::appendChoiceChunk($chunks, $merged, [
+                    'id' => 'chunk-' . $chunkId++,
+                    'state' => $state,
+                    'base' => $baseVariant,
+                    'local' => $localVariant,
+                    'incoming' => $incomingVariant,
+                    'defaultChoice' => 'incoming',
+                ]);
+                $choiceCount++;
+            }
+
+            $position = $groupEnd;
+        }
+
+        static::appendContextChunk($chunks, $merged, $base, $position, count($base));
+
+        return [
+            'lineEnding' => base64_encode($lineEnding),
+            'chunks' => $chunks,
+            'mergedContent' => base64_encode(static::joinLines($merged, $lineEnding)),
+            'hasChoices' => $choiceCount > 0,
+            'hasConflicts' => $conflictCount > 0,
+            'choiceCount' => $choiceCount,
+            'conflictCount' => $conflictCount,
+        ];
+    }
+
+    /**
+     * Build a whole-file merge fallback when chunk detection is unavailable.
+     *
+     * @param string $baseContent
+     * @param string $localContent
+     * @param string $incomingContent
+     *
+     * @return array
+     */
+    public static function buildWholeFilePreview($baseContent, $localContent, $incomingContent)
+    {
+        $lineEnding = static::detectLineEnding($localContent, $incomingContent, $baseContent);
+        $defaultChoice = 'incoming';
+
+        return [
+            'lineEnding' => base64_encode($lineEnding),
+            'chunks' => [[
+                'type' => 'choice',
+                'id' => 'chunk-1',
+                'state' => 'conflict',
+                'defaultChoice' => $defaultChoice,
+                'base' => base64_encode($baseContent),
+                'local' => base64_encode($localContent),
+                'incoming' => base64_encode($incomingContent),
+            ]],
+            'mergedContent' => base64_encode($defaultChoice === 'local' ? $localContent : $incomingContent),
+            'hasChoices' => true,
+            'hasConflicts' => true,
+            'choiceCount' => 1,
+            'conflictCount' => 1,
+            'fallback' => true,
+        ];
+    }
+
+    /**
+     * Build a simple unified-style preview between two text blobs.
+     *
+     * @param string $fromContent
+     * @param string $toContent
+     * @param string $fromLabel
+     * @param string $toLabel
+     *
+     * @return string
+     */
+    public static function buildDiff($fromContent, $toContent, $fromLabel = 'local', $toLabel = 'incoming')
+    {
+        $from = static::splitLines($fromContent);
+        $to = static::splitLines($toContent);
+        $ops = static::calculateOperations($from, $to);
+
+        $lines = [
+            '--- ' . $fromLabel . "\n",
+            '+++ ' . $toLabel . "\n",
+        ];
+
+        foreach ($ops as $op) {
+            switch ($op['type']) {
+                case 'equal':
+                    $lines[] = ' ' . $op['line'];
+                    break;
+                case 'delete':
+                    $lines[] = '-' . $op['line'];
+                    break;
+                case 'insert':
+                    $lines[] = '+' . $op['line'];
+                    break;
+            }
+        }
+
+        return implode('', $lines);
+    }
+
+    /**
+     * @param array $chunks
+     * @param array $merged
+     * @param array $base
+     * @param int $start
+     * @param int $end
+     *
+     * @return void
+     */
+    private static function appendContextChunk(&$chunks, &$merged, $base, $start, $end)
+    {
+        if ($end <= $start) {
+            return;
+        }
+
+        $lines = array_slice($base, $start, $end - $start);
+        $chunks[] = [
+            'type' => 'context',
+            'content' => base64_encode(static::joinLines($lines, "\n")),
+        ];
+        $merged = array_merge($merged, $lines);
+    }
+
+    /**
+     * @param array $chunks
+     * @param array $merged
+     * @param array $chunk
+     *
+     * @return void
+     */
+    private static function appendChoiceChunk(&$chunks, &$merged, $chunk)
+    {
+        $chunks[] = [
+            'type' => 'choice',
+            'id' => $chunk['id'],
+            'state' => $chunk['state'],
+            'defaultChoice' => $chunk['defaultChoice'],
+            'base' => base64_encode(static::joinLines($chunk['base'], "\n")),
+            'local' => base64_encode(static::joinLines($chunk['local'], "\n")),
+            'incoming' => base64_encode(static::joinLines($chunk['incoming'], "\n")),
+        ];
+        $merged = array_merge($merged, $chunk[$chunk['defaultChoice']]);
+    }
+
+    /**
+     * @param array $base
+     * @param array $target
+     *
+     * @return array
+     */
+    private static function buildChanges($base, $target)
+    {
+        $changes = static::buildChangesUsingDiff($base, $target);
+        if ($changes !== null) {
+            return $changes;
+        }
+
+        $ops = static::calculateOperations($base, $target);
+        $changes = [];
+        $baseIndex = 0;
+        $targetIndex = 0;
+        $current = null;
+
+        foreach ($ops as $op) {
+            if ($op['type'] === 'equal') {
+                if ($current) {
+                    $current['end'] = $baseIndex;
+                    $changes[] = $current;
+                    $current = null;
+                }
+                $baseIndex++;
+                $targetIndex++;
+                continue;
+            }
+
+            if (! $current) {
+                $current = [
+                    'start' => $baseIndex,
+                    'end' => $baseIndex,
+                    'replacement' => [],
+                ];
+            }
+
+            if ($op['type'] === 'delete') {
+                $baseIndex++;
+            } else {
+                $current['replacement'][] = $target[$targetIndex];
+                $targetIndex++;
+            }
+        }
+
+        if ($current) {
+            $current['end'] = $baseIndex;
+            $changes[] = $current;
+        }
+
+        return $changes;
+    }
+
+    /**
+     * @param array $base
+     * @param int $start
+     * @param int $end
+     * @param array $changes
+     *
+     * @return array
+     */
+    private static function applyChanges($base, $start, $end, $changes)
+    {
+        $result = [];
+        $cursor = $start;
+
+        foreach ($changes as $change) {
+            if ($change['start'] > $cursor) {
+                $result = array_merge($result, array_slice($base, $cursor, $change['start'] - $cursor));
+            }
+            $result = array_merge($result, $change['replacement']);
+            $cursor = $change['end'];
+        }
+
+        if ($cursor < $end) {
+            $result = array_merge($result, array_slice($base, $cursor, $end - $cursor));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $from
+     * @param array $to
+     *
+     * @return array
+     */
+    private static function calculateOperations($from, $to)
+    {
+        $fromCount = count($from);
+        $toCount = count($to);
+
+        if ($fromCount === 0 && $toCount === 0) {
+            return [];
+        }
+
+        if ($fromCount > static::MATRIX_FALLBACK_LIMIT || $toCount > static::MATRIX_FALLBACK_LIMIT) {
+            return static::buildOperationsLinearly($from, $to);
+        }
+
+        $matrix = [];
+        for ($fromIndex = 0; $fromIndex <= $fromCount; $fromIndex++) {
+            $matrix[$fromIndex] = array_fill(0, $toCount + 1, 0);
+        }
+
+        $operations = [];
+        for ($fromIndex = $fromCount - 1; $fromIndex >= 0; $fromIndex--) {
+            for ($toIndex = $toCount - 1; $toIndex >= 0; $toIndex--) {
+                if ($from[$fromIndex] === $to[$toIndex]) {
+                    $matrix[$fromIndex][$toIndex] = $matrix[$fromIndex + 1][$toIndex + 1] + 1;
+                } else {
+                    $matrix[$fromIndex][$toIndex] = max($matrix[$fromIndex + 1][$toIndex], $matrix[$fromIndex][$toIndex + 1]);
+                }
+            }
+        }
+
+        $fromIndex = 0;
+        $toIndex = 0;
+        while ($fromIndex < $fromCount && $toIndex < $toCount) {
+            if ($from[$fromIndex] === $to[$toIndex]) {
+                $operations[] = [
+                    'type' => 'equal',
+                    'line' => $from[$fromIndex],
+                ];
+                $fromIndex++;
+                $toIndex++;
+            } elseif ($matrix[$fromIndex + 1][$toIndex] >= $matrix[$fromIndex][$toIndex + 1]) {
+                $operations[] = [
+                    'type' => 'delete',
+                    'line' => $from[$fromIndex],
+                ];
+                $fromIndex++;
+            } else {
+                $operations[] = [
+                    'type' => 'insert',
+                    'line' => $to[$toIndex],
+                ];
+                $toIndex++;
+            }
+        }
+
+        while ($fromIndex < $fromCount) {
+            $operations[] = [
+                'type' => 'delete',
+                'line' => $from[$fromIndex],
+            ];
+            $fromIndex++;
+        }
+
+        while ($toIndex < $toCount) {
+            $operations[] = [
+                'type' => 'insert',
+                'line' => $to[$toIndex],
+            ];
+            $toIndex++;
+        }
+
+        return $operations;
+    }
+
+    /**
+     * Try to calculate changes using external diff utility.
+     *
+     * @param array $base
+     * @param array $target
+     *
+     * @return array|null
+     */
+    private static function buildChangesUsingDiff($base, $target)
+    {
+        $diff = static::runDiff(
+            static::joinLines($base, "\n"),
+            static::joinLines($target, "\n"),
+            0,
+            'base',
+            'target'
+        );
+
+        if ($diff === null) {
+            return null;
+        }
+
+        if ($diff === '') {
+            return [];
+        }
+
+        if (strpos($diff, '@@ ') === false) {
+            return null;
+        }
+
+        $changes = [];
+        $lines = preg_split("/\r\n|\n|\r/", $diff);
+        foreach ($lines as $line) {
+            if (!preg_match('/^@@ -([0-9]+)(?:,([0-9]+))? \+([0-9]+)(?:,([0-9]+))? @@/', $line, $matches)) {
+                continue;
+            }
+
+            $baseStart = (int)$matches[1];
+            $baseCount = isset($matches[2]) && $matches[2] !== '' ? (int)$matches[2] : 1;
+            $targetStart = (int)$matches[3];
+            $targetCount = isset($matches[4]) && $matches[4] !== '' ? (int)$matches[4] : 1;
+
+            $baseIndex = $baseCount === 0 ? $baseStart : max(0, $baseStart - 1);
+            $targetIndex = $targetCount === 0 ? $targetStart : max(0, $targetStart - 1);
+
+            $changes[] = [
+                'start' => $baseIndex,
+                'end' => $baseIndex + $baseCount,
+                'replacement' => array_slice($target, $targetIndex, $targetCount),
+            ];
+        }
+
+        return $changes;
+    }
+
+    /**
+     * Build operations in linear time for large files.
+     *
+     * This fallback treats the remaining tail as one replacement block.
+     *
+     * @param array $from
+     * @param array $to
+     *
+     * @return array
+     */
+    private static function buildOperationsLinearly($from, $to)
+    {
+        $fromCount = count($from);
+        $toCount = count($to);
+        $prefix = 0;
+        while ($prefix < $fromCount && $prefix < $toCount && $from[$prefix] === $to[$prefix]) {
+            $prefix++;
+        }
+
+        $suffix = 0;
+        while (
+            $suffix < ($fromCount - $prefix) &&
+            $suffix < ($toCount - $prefix) &&
+            $from[$fromCount - $suffix - 1] === $to[$toCount - $suffix - 1]
+        ) {
+            $suffix++;
+        }
+
+        $operations = [];
+        for ($index = 0; $index < $prefix; $index++) {
+            $operations[] = [
+                'type' => 'equal',
+                'line' => $from[$index],
+            ];
+        }
+
+        for ($index = $prefix; $index < $fromCount - $suffix; $index++) {
+            $operations[] = [
+                'type' => 'delete',
+                'line' => $from[$index],
+            ];
+        }
+
+        for ($index = $prefix; $index < $toCount - $suffix; $index++) {
+            $operations[] = [
+                'type' => 'insert',
+                'line' => $to[$index],
+            ];
+        }
+
+        for ($index = $fromCount - $suffix; $index < $fromCount; $index++) {
+            $operations[] = [
+                'type' => 'equal',
+                'line' => $from[$index],
+            ];
+        }
+
+        return $operations;
+    }
+
+    /**
+     * @param string $fromContent
+     * @param string $toContent
+     * @param int $contextLines
+     * @param string $fromLabel
+     * @param string $toLabel
+     *
+     * @return string|null
+     */
+    private static function runDiff($fromContent, $toContent, $contextLines, $fromLabel, $toLabel)
+    {
+        if (!function_exists('shell_exec')) {
+            return null;
+        }
+
+        $tempDir = static::getTempDirectory();
+        $tmpFrom = tempnam($tempDir, 'cud');
+        $tmpTo = tempnam($tempDir, 'cud');
+        if (!$tmpFrom || !$tmpTo) {
+            return null;
+        }
+
+        try {
+            file_put_contents($tmpFrom, $fromContent);
+            file_put_contents($tmpTo, $toContent);
+
+            $command = sprintf(
+                'diff -U %d --label %s --label %s %s %s 2>&1',
+                (int)$contextLines,
+                escapeshellarg($fromLabel),
+                escapeshellarg($toLabel),
+                escapeshellarg($tmpFrom),
+                escapeshellarg($tmpTo)
+            );
+
+            $output = shell_exec($command);
+            if ($output === null) {
+                return null;
+            }
+
+            return preg_replace('/^(--- .*\R\+\+\+ .*\R)/', '', $output, 1);
+        } finally {
+            @unlink($tmpFrom);
+            @unlink($tmpTo);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private static function getTempDirectory()
+    {
+        if (defined('_PS_CACHE_DIR_') && _PS_CACHE_DIR_ && is_dir(_PS_CACHE_DIR_)) {
+            return _PS_CACHE_DIR_;
+        }
+        return sys_get_temp_dir();
+    }
+
+    /**
+     * @param array $left
+     * @param array $right
+     *
+     * @return bool
+     */
+    private static function changeBefore($left, $right)
+    {
+        if ($left['start'] < $right['start']) {
+            return true;
+        }
+
+        if ($left['start'] > $right['start']) {
+            return false;
+        }
+
+        return $left['end'] <= $right['end'];
+    }
+
+    /**
+     * @param array $left
+     * @param array $right
+     *
+     * @return bool
+     */
+    private static function changesOverlap($left, $right)
+    {
+        $leftInsert = $left['start'] === $left['end'];
+        $rightInsert = $right['start'] === $right['end'];
+
+        if ($leftInsert && $rightInsert) {
+            return $left['start'] === $right['start'];
+        }
+
+        if ($leftInsert) {
+            return $left['start'] > $right['start'] && $left['start'] < $right['end'];
+        }
+
+        if ($rightInsert) {
+            return $right['start'] > $left['start'] && $right['start'] < $left['end'];
+        }
+
+        return $left['start'] < $right['end'] && $right['start'] < $left['end'];
+    }
+
+    /**
+     * @param array $change
+     * @param int $start
+     * @param int $end
+     *
+     * @return bool
+     */
+    private static function changeTouchesSpan($change, $start, $end)
+    {
+        if ($change['start'] === $change['end']) {
+            if ($start === $end) {
+                return $change['start'] === $start;
+            }
+            return $change['start'] >= $start && $change['start'] <= $end;
+        }
+
+        return $change['start'] < $end && $change['end'] > $start;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return array
+     */
+    private static function splitLines($content)
+    {
+        if ($content === '' || $content === null) {
+            return [];
+        }
+
+        $normalized = str_replace(["\r\n", "\r"], "\n", $content);
+        $lines = preg_split('/(?<=\n)/', $normalized);
+        if ($lines && end($lines) === '') {
+            array_pop($lines);
+        }
+        return $lines;
+    }
+
+    /**
+     * @param array $lines
+     * @param string $lineEnding
+     *
+     * @return string
+     */
+    private static function joinLines($lines, $lineEnding)
+    {
+        $content = implode('', $lines);
+        if ($lineEnding !== "\n") {
+            $content = str_replace("\n", $lineEnding, $content);
+        }
+        return $content;
+    }
+
+    /**
+     * @param string $localContent
+     * @param string $incomingContent
+     * @param string $baseContent
+     *
+     * @return string
+     */
+    private static function detectLineEnding($localContent, $incomingContent, $baseContent)
+    {
+        foreach ([$localContent, $incomingContent, $baseContent] as $content) {
+            if (strpos($content, "\r\n") !== false) {
+                return "\r\n";
+            }
+            if (strpos($content, "\n") !== false) {
+                return "\n";
+            }
+        }
+        return "\n";
+    }
+}

--- a/classes/process/Updater.php
+++ b/classes/process/Updater.php
@@ -44,6 +44,7 @@ class Updater extends Processor
     const ACTION_VERIFY = 'VERIFY_FILES';
     const ACTION_RENAME_DIR = 'RENAME_DIRECTORY';
     const ACTION_BACKUP = 'BACKUP';
+    const ACTION_APPLY_MERGED_FILES = 'APPLY_MERGED_FILES';
     const ACTION_CREATE_UPDATE_SCRIPT = 'CREATE_UPDATE_SCRIPT';
     const ACTION_UPDATE = 'UPDATE';
     const ACTION_POST_PROCESS_AFTER_UPDATE = 'POST_PROCESS_AFTER_UPDATE';
@@ -139,6 +140,7 @@ class Updater extends Processor
         $versionName = $settings['versionName'];
         $changeSet = $settings['changeSet'];
         $targetFileList = $settings['targetFileList'];
+        $mergedFiles = isset($settings['mergedFiles']) ? $settings['mergedFiles'] : [];
         $stagingDirectory = $this->stagingDir;
         $scriptPath = $this->rootDir . 'coreupdater.php';
         $scriptUrl = $this->baseUrl . '/coreupdater.php?' . time();
@@ -149,6 +151,7 @@ class Updater extends Processor
 
         $toDownload = $this->getFilesToDownload($changeSet, $targetFileList);
         $sources = [];
+        $stagingTargets = [];
 
         $chunks = array_chunk(array_keys($toDownload), $this->chunkSize);
         $steps = [];
@@ -167,6 +170,7 @@ class Updater extends Processor
                     $admin = true;
                 }
                 $sources[$dir . $targetFile] = $this->rootDir.$targetFile;
+                $stagingTargets[$targetFile] = $dir . $targetFile;
             }
 
             $steps[] = [
@@ -211,6 +215,20 @@ class Updater extends Processor
                     'to' => $this->backupDir
                 ];
             }
+        }
+
+        if ($mergedFiles) {
+            $resolvedMergedFiles = [];
+            foreach ($mergedFiles as $path => $content) {
+                if (!isset($stagingTargets[$path])) {
+                    throw new PrestaShopException("Unable to prepare merged file $path");
+                }
+                $resolvedMergedFiles[$stagingTargets[$path]] = $content;
+            }
+            $steps[] = [
+                'action' => static::ACTION_APPLY_MERGED_FILES,
+                'files' => $resolvedMergedFiles,
+            ];
         }
 
         $toRemove = $this->getFilesToDelete($changeSet);
@@ -300,6 +318,10 @@ class Updater extends Processor
                     $step['files'],
                     $step['to']
                 );
+            case static::ACTION_APPLY_MERGED_FILES:
+                return $this->applyMergedFiles(
+                    $step['files']
+                );
             case static::ACTION_CREATE_UPDATE_SCRIPT:
                 return $this->createUpdateScript(
                     $processId,
@@ -358,6 +380,8 @@ class Updater extends Processor
                 return sprintf($this->l('Renaming directory %s to %s'), $step['from'], $step['to']);
             case static::ACTION_BACKUP:
                 return $this->l('Backuping files');
+            case static::ACTION_APPLY_MERGED_FILES:
+                return $this->l('Preparing merged files');
             case static::ACTION_CREATE_UPDATE_SCRIPT:
                 return $this->l('Generating update script');
             case static::ACTION_UPDATE:
@@ -504,6 +528,28 @@ class Updater extends Processor
                     @mkdir($dir, 0777, true);
                 }
                 @copy($source, $target);
+            }
+        }
+        return ProcessingState::done();
+    }
+
+    /**
+     * Writes merged file contents into staging directory.
+     *
+     * @param array $files
+     * @return ProcessingState
+     * @throws PrestaShopException
+     */
+    protected function applyMergedFiles($files)
+    {
+        foreach ($files as $target => $content) {
+            $decoded = base64_decode($content, true);
+            if ($decoded === false) {
+                throw new PrestaShopException("Invalid merged file content for $target");
+            }
+            $this->ensureDirectoryExists(dirname($target));
+            if (file_put_contents($target, $decoded) === false) {
+                throw new PrestaShopException("Failed to write merged file $target");
             }
         }
         return ProcessingState::done();

--- a/controllers/admin/AdminCoreUpdaterController.php
+++ b/controllers/admin/AdminCoreUpdaterController.php
@@ -49,6 +49,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
     const ACTION_GET_DATABASE_DIFFERENCES = "GET_DATABASE_DIFFERENCES";
     const ACTION_APPLY_DATABASE_FIX = 'APPLY_DATABASE_FIX';
     const ACTION_RUN_POST_UPDATE_PROCESSES = 'RUN_POST_UPDATE_PROCESSES';
+    const ACTION_PREVIEW_FILE = 'PREVIEW_FILE';
 
     const SELECTED_PROCESS_MIGRATE_DB = 'SELECTED_PROCESS_MIGRATE_DB';
     const SELECTED_PROCESS_INITIALIZATION_CALLBACK = 'SELECTED_PROCESS_INITIALIZATION_CALLBACK';
@@ -777,6 +778,8 @@ class AdminCoreUpdaterController extends ModuleAdminController
                 return $this->getDatabaseDifferences();
             case static::ACTION_APPLY_DATABASE_FIX:
                 return $this->applyDatabaseFix(Tools::getValue('ids'));
+            case static::ACTION_PREVIEW_FILE:
+                return $this->previewFile();
             default:
                 throw new PrestaShopException("Invalid action: $action");
         }
@@ -955,6 +958,19 @@ class AdminCoreUpdaterController extends ModuleAdminController
         if (! $result) {
             throw new PrestaShopException("Comparision result not found. Please reload the page and try again");
         }
+        $ignored = Tools::getValue('ignoreFiles');
+        if ($ignored && !is_array($ignored)) {
+            $ignored = [$ignored];
+        }
+        if ($ignored) {
+            foreach ($ignored as $path) {
+                foreach (['change','add','remove'] as $type) {
+                    if (isset($result['changeSet'][$type][$path])) {
+                        unset($result['changeSet'][$type][$path]);
+                    }
+                }
+            }
+        }
         $targetFileList = $comparator->getFileList(
             $compareProcessId,
             $result['targetRevision'],
@@ -977,6 +993,61 @@ class AdminCoreUpdaterController extends ModuleAdminController
             'progress' => 0.0,
             'step' => $updater->describeCurrentStep($processId),
         ];
+    }
+
+    /**
+     * Returns preview of given file
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    protected function previewFile()
+    {
+        $compareProcessId = Tools::getValue('compareProcessId');
+        $file = Tools::getValue('file');
+        if (!$file) {
+            throw new PrestaShopException('File not specified');
+        }
+        $comparator = $this->factory->getComparator();
+        $result = $comparator->getResult($compareProcessId);
+        if (!$result) {
+            throw new PrestaShopException('Comparision result not found. Please reload the page and try again');
+        }
+        $apiPath = preg_replace('#^' . preg_quote(basename(_PS_ADMIN_DIR_) . '/') . '#', 'admin/', $file);
+        $tmp = tempnam(_PS_CACHE_DIR_, 'cu');
+        try {
+            $this->factory->getApi()->downloadFiles(
+                $result['targetPHPVersion'],
+                $result['targetRevision'],
+                [ $apiPath ],
+                $tmp
+            );
+            $tar = new Archive_Tar($tmp);
+            $remoteContent = $tar->extractInString($apiPath);
+        } finally {
+            @unlink($tmp);
+        }
+
+        $localPath = _PS_ROOT_DIR_ . '/' . $this->fixAdminDirectory($file);
+        $localContent = file_exists($localPath) ? file_get_contents($localPath) : '';
+
+        return [
+            'local' => $localContent,
+            'remote' => $remoteContent,
+        ];
+    }
+
+    /**
+     * Replace admin directory placeholder with real directory name
+     *
+     * @param string $file
+     * @return string
+     */
+    protected function fixAdminDirectory($file)
+    {
+        $adminDir = basename(_PS_ADMIN_DIR_);
+        return preg_replace('#^admin/#', $adminDir . '/', $file);
     }
 
     /**

--- a/controllers/admin/AdminCoreUpdaterController.php
+++ b/controllers/admin/AdminCoreUpdaterController.php
@@ -938,7 +938,8 @@ class AdminCoreUpdaterController extends ModuleAdminController
             'versionType' => $versionType,
             'installedRevision' => $installedRevision,
             'targetRevision' => $targetRevision,
-            'changeSet' => $changeSet
+            'changeSet' => $changeSet,
+            'developerMode' => Settings::isDeveloperMode(),
         ]);
 
         return [
@@ -958,15 +959,18 @@ class AdminCoreUpdaterController extends ModuleAdminController
         if (! $result) {
             throw new PrestaShopException("Comparision result not found. Please reload the page and try again");
         }
-        $ignored = Tools::getValue('ignoreFiles');
-        if ($ignored && !is_array($ignored)) {
-            $ignored = [$ignored];
-        }
-        if ($ignored) {
-            foreach ($ignored as $path) {
-                foreach (['change','add','remove'] as $type) {
-                    if (isset($result['changeSet'][$type][$path])) {
-                        unset($result['changeSet'][$type][$path]);
+        $ignored = null;
+        if (Settings::isDeveloperMode()) {
+            $ignored = Tools::getValue('ignoreFiles');
+            if ($ignored && !is_array($ignored)) {
+                $ignored = [$ignored];
+            }
+            if ($ignored) {
+                foreach ($ignored as $path) {
+                    foreach (['change','add','remove'] as $type) {
+                        if (isset($result['changeSet'][$type][$path])) {
+                            unset($result['changeSet'][$type][$path]);
+                        }
                     }
                 }
             }
@@ -1004,6 +1008,9 @@ class AdminCoreUpdaterController extends ModuleAdminController
      */
     protected function previewFile()
     {
+        if (!Settings::isDeveloperMode()) {
+            throw new PrestaShopException('Developer mode is not enabled');
+        }
         $compareProcessId = Tools::getValue('compareProcessId');
         $file = Tools::getValue('file');
         if (!$file) {
@@ -1032,9 +1039,17 @@ class AdminCoreUpdaterController extends ModuleAdminController
         $localPath = _PS_ROOT_DIR_ . '/' . $this->fixAdminDirectory($file);
         $localContent = file_exists($localPath) ? file_get_contents($localPath) : '';
 
+        $tmpRemote = tempnam(_PS_CACHE_DIR_, 'cu');
+        $tmpLocal = tempnam(_PS_CACHE_DIR_, 'cu');
+        file_put_contents($tmpRemote, $remoteContent);
+        file_put_contents($tmpLocal, $localContent);
+        $cmd = sprintf('diff -u %s %s 2>&1', escapeshellarg($tmpLocal), escapeshellarg($tmpRemote));
+        $diff = shell_exec($cmd);
+        @unlink($tmpRemote);
+        @unlink($tmpLocal);
+
         return [
-            'local' => $localContent,
-            'remote' => $remoteContent,
+            'diff' => base64_encode($diff === null ? '' : $diff),
         ];
     }
 

--- a/controllers/admin/AdminCoreUpdaterController.php
+++ b/controllers/admin/AdminCoreUpdaterController.php
@@ -22,6 +22,7 @@ use CoreUpdater\Api\ThirtybeesApiException;
 use CoreUpdater\DatabaseSchemaComparator;
 use CoreUpdater\Factory;
 use CoreUpdater\InformationSchemaBuilder;
+use CoreUpdater\MergeService;
 use CoreUpdater\ObjectModelSchemaBuilder;
 use CoreUpdater\Process\ProcessingState;
 use CoreUpdater\Process\Processor;
@@ -745,7 +746,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
                 'success' => true,
                 'data' => $this->processAction($action)
             ]));
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $logger->error('Failed to process action ' . $action . ': ' . $e->getMessage() . ': ' . $e->getTraceAsString());
             die(json_encode([
                 'success' => false,
@@ -914,6 +915,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
     public function createCompareResult($compareProcessId, $result, $installedRevision)
     {
         $changeSet = $result['changeSet'];
+        $previewableFiles = $this->buildPreviewableFilesMap($changeSet);
         $targetRevision = $result['targetRevision'];
         $sameRevision = $targetRevision == $installedRevision;
         $changes = 0;
@@ -939,6 +941,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
             'installedRevision' => $installedRevision,
             'targetRevision' => $targetRevision,
             'changeSet' => $changeSet,
+            'previewableFiles' => $previewableFiles,
             'developerMode' => Settings::isDeveloperMode(),
         ]);
 
@@ -975,6 +978,7 @@ class AdminCoreUpdaterController extends ModuleAdminController
                 }
             }
         }
+        $mergedFiles = $this->parseMergedFiles(Tools::getValue('mergedFiles'), $result['changeSet']);
         $targetFileList = $comparator->getFileList(
             $compareProcessId,
             $result['targetRevision'],
@@ -989,7 +993,8 @@ class AdminCoreUpdaterController extends ModuleAdminController
             'versionType' => $result['versionType'],
             'versionName' => $result['versionName'],
             'changeSet' => $result['changeSet'],
-            'targetFileList' => $targetFileList
+            'targetFileList' => $targetFileList,
+            'mergedFiles' => $mergedFiles,
         ]);
         return [
             'id' => $processId,
@@ -1008,9 +1013,6 @@ class AdminCoreUpdaterController extends ModuleAdminController
      */
     protected function previewFile()
     {
-        if (!Settings::isDeveloperMode()) {
-            throw new PrestaShopException('Developer mode is not enabled');
-        }
         $compareProcessId = Tools::getValue('compareProcessId');
         $file = Tools::getValue('file');
         if (!$file) {
@@ -1021,36 +1023,185 @@ class AdminCoreUpdaterController extends ModuleAdminController
         if (!$result) {
             throw new PrestaShopException('Comparision result not found. Please reload the page and try again');
         }
-        $apiPath = preg_replace('#^' . preg_quote(basename(_PS_ADMIN_DIR_) . '/') . '#', 'admin/', $file);
-        $tmp = tempnam(_PS_CACHE_DIR_, 'cu');
-        try {
-            $this->factory->getApi()->downloadFiles(
-                $result['targetPHPVersion'],
-                $result['targetRevision'],
-                [ $apiPath ],
-                $tmp
-            );
-            $tar = new Archive_Tar($tmp);
-            $remoteContent = $tar->extractInString($apiPath);
-        } finally {
-            @unlink($tmp);
+        $changeSet = $result['changeSet'];
+        $changeType = $this->resolveChangeType($changeSet, $file);
+        if (!$changeType) {
+            throw new PrestaShopException('File does not belong to current compare result');
+        }
+        if (!$this->isPreviewableFile($file, $changeType)) {
+            throw new PrestaShopException('Preview is not available for this file');
         }
 
+        $mergeable = $changeType === 'change' && !empty($changeSet['change'][$file]);
+        if (!$mergeable && !Settings::isDeveloperMode()) {
+            throw new PrestaShopException('Developer mode is not enabled');
+        }
+
+        $apiPath = preg_replace('#^' . preg_quote(basename(_PS_ADMIN_DIR_) . '/') . '#', 'admin/', $file);
         $localPath = _PS_ROOT_DIR_ . '/' . $this->fixAdminDirectory($file);
         $localContent = file_exists($localPath) ? file_get_contents($localPath) : '';
 
-        $tmpRemote = tempnam(_PS_CACHE_DIR_, 'cu');
-        $tmpLocal = tempnam(_PS_CACHE_DIR_, 'cu');
-        file_put_contents($tmpRemote, $remoteContent);
-        file_put_contents($tmpLocal, $localContent);
-        $cmd = sprintf('diff -u %s %s 2>&1', escapeshellarg($tmpLocal), escapeshellarg($tmpRemote));
-        $diff = shell_exec($cmd);
-        @unlink($tmpRemote);
-        @unlink($tmpLocal);
+        $incomingContent = '';
+        if ($changeType !== 'remove') {
+            $incomingContent = $this->downloadRevisionFile(
+                $result['targetPHPVersion'],
+                $result['targetRevision'],
+                $apiPath
+            );
+        }
+
+        if ($mergeable) {
+            try {
+                $comparator = $this->factory->getComparator();
+                $baseContent = $this->downloadRevisionFile(
+                    $comparator->getOriginPHPVersion(),
+                    $comparator->getInstalledRevision(),
+                    $apiPath
+                );
+                $preview = MergeService::buildMergePreview($baseContent, $localContent, $incomingContent);
+            } catch (\Throwable $e) {
+                $this->factory->getLogger()->error('Falling back to whole-file merge preview for ' . $file . ': ' . $e->getMessage());
+                $preview = MergeService::buildWholeFilePreview('', $localContent, $incomingContent);
+            }
+            $preview['mode'] = 'merge';
+            return $preview;
+        }
 
         return [
-            'diff' => base64_encode($diff === null ? '' : $diff),
+            'mode' => 'diff',
+            'diff' => base64_encode(MergeService::buildDiff($localContent, $incomingContent)),
         ];
+    }
+
+    /**
+     * @param string|null $payload
+     * @param array $changeSet
+     *
+     * @return array
+     * @throws PrestaShopException
+     */
+    protected function parseMergedFiles($payload, $changeSet)
+    {
+        if (!$payload) {
+            return [];
+        }
+
+        $data = json_decode($payload, true);
+        if (!is_array($data)) {
+            throw new PrestaShopException('Invalid merged files payload');
+        }
+
+        $mergedFiles = [];
+        foreach ($data as $file => $content) {
+            if (!isset($changeSet['change'][$file]) || !$changeSet['change'][$file]) {
+                throw new PrestaShopException("Merged content is not allowed for file $file");
+            }
+            if (!is_string($content) || base64_decode($content, true) === false) {
+                throw new PrestaShopException("Invalid merged content for file $file");
+            }
+            $mergedFiles[$file] = $content;
+        }
+
+        return $mergedFiles;
+    }
+
+    /**
+     * @param array $changeSet
+     * @param string $file
+     *
+     * @return string|null
+     */
+    protected function resolveChangeType($changeSet, $file)
+    {
+        foreach (['change', 'add', 'remove'] as $type) {
+            if (isset($changeSet[$type][$file])) {
+                return $type;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param array $changeSet
+     *
+     * @return array
+     */
+    protected function buildPreviewableFilesMap($changeSet)
+    {
+        $previewableFiles = [];
+        foreach (['change', 'add', 'remove'] as $type) {
+            if (empty($changeSet[$type]) || !is_array($changeSet[$type])) {
+                continue;
+            }
+            foreach ($changeSet[$type] as $file => $modified) {
+                $previewableFiles[$file] = $this->isPreviewableFile($file, $type);
+            }
+        }
+
+        return $previewableFiles;
+    }
+
+    /**
+     * @param string $file
+     * @param string|null $changeType
+     *
+     * @return bool
+     */
+    protected function isPreviewableFile($file, $changeType = null)
+    {
+        $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+        $binaryExtensions = [
+            '7z', 'avi', 'bin', 'bmp', 'class', 'cur', 'dll', 'eot', 'exe',
+            'flac', 'gif', 'gz', 'ico', 'jar', 'jpeg', 'jpg', 'mp3', 'mp4',
+            'mov', 'ogg', 'otf', 'pdf', 'phar', 'png', 'psd', 'rar', 'so',
+            'svgz', 'tar', 'tgz', 'ttf', 'wav', 'webm', 'webp', 'woff',
+            'woff2', 'zip',
+        ];
+
+        if ($extension && in_array($extension, $binaryExtensions, true)) {
+            return false;
+        }
+
+        if ($changeType !== 'add') {
+            $localPath = _PS_ROOT_DIR_ . '/' . $this->fixAdminDirectory($file);
+            if (is_file($localPath)) {
+                $sample = file_get_contents($localPath, false, null, 0, 4096);
+                if ($sample !== false && strpos($sample, "\0") !== false) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $phpVersion
+     * @param string $revision
+     * @param string $path
+     *
+     * @return string
+     * @throws PrestaShopException
+     */
+    protected function downloadRevisionFile($phpVersion, $revision, $path)
+    {
+        $tmp = tempnam(_PS_CACHE_DIR_, 'cu');
+        try {
+            $this->factory->getApi()->downloadFiles(
+                $phpVersion,
+                $revision,
+                [$path],
+                $tmp
+            );
+            $tar = new Archive_Tar($tmp, 'gz');
+            $content = $tar->extractInString($path);
+            if ($content === false) {
+                throw new PrestaShopException("Failed to extract file $path from revision $revision");
+            }
+            return $content;
+        } finally {
+            @unlink($tmp);
+        }
     }
 
     /**

--- a/views/css/coreupdater.css
+++ b/views/css/coreupdater.css
@@ -96,3 +96,19 @@
     top: 50%;
     left: 50%;
 }
+
+/* File preview diff styles */
+#file-preview-diff {
+    max-height: 70vh;
+    overflow: auto;
+    background: #f8f8f8;
+    padding: 10px;
+}
+#file-preview-diff .diff-add { background-color: #e6ffed; }
+#file-preview-diff .diff-del { background-color: #ffeef0; }
+#file-preview-diff .diff-hunk { background-color: #f1f8ff; }
+
+.ignore-label {
+    font-weight: normal;
+    margin-left: 5px;
+}

--- a/views/css/coreupdater.css
+++ b/views/css/coreupdater.css
@@ -109,6 +109,6 @@
 #file-preview-diff .diff-hunk { background-color: #f1f8ff; }
 
 .ignore-label {
-    font-weight: normal;
-    margin-left: 5px;
+    font-weight: normal !important;
+    margin: 0 0 0 5px;
 }

--- a/views/css/coreupdater.css
+++ b/views/css/coreupdater.css
@@ -36,6 +36,16 @@
     line-height: 18px;
 }
 
+.file-section h4 {
+    margin-bottom: 4px;
+}
+
+.file-section-note {
+    margin: 0 0 10px;
+    color: #6c7a89;
+    font-size: 12px;
+}
+
 .file-list li .badge {
     line-height: 12px;
     font-size: 10px;
@@ -101,8 +111,10 @@
 #file-preview-diff {
     max-height: 70vh;
     overflow: auto;
-    background: #f8f8f8;
-    padding: 10px;
+    background: #f7f9fc;
+    border: 1px solid #dfe7f1;
+    border-radius: 6px;
+    padding: 14px;
 }
 #file-preview-diff .diff-add { background-color: #c8f7cf; }
 #file-preview-diff .diff-del { background-color: #ffd2d7; }
@@ -111,4 +123,276 @@
 .ignore-label {
     font-weight: normal !important;
     margin: 0 0 0 5px;
+}
+
+.file-list li .btn {
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+.merge-state {
+    margin-left: 6px;
+}
+
+.merge-file-path {
+    margin: 6px 0 0;
+    color: #7f8c8d;
+    word-break: break-all;
+}
+
+#file-preview-modal .modal-dialog {
+    width: 92%;
+    max-width: 1440px;
+}
+
+.merge-toolbar {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    flex-wrap: wrap;
+}
+
+#merge-select-local {
+    background: #fbe4e1;
+    border-color: #e7b8b1;
+    color: #8f2f25;
+}
+
+#merge-select-local:hover,
+#merge-select-local:focus {
+    background: #f7d1cb;
+    border-color: #dc9a90;
+    color: #7b251d;
+}
+
+#merge-select-incoming {
+    background: #e4f6ea;
+    border-color: #b8dfc3;
+    color: #206b3e;
+}
+
+#merge-select-incoming:hover,
+#merge-select-incoming:focus {
+    background: #d2efd9;
+    border-color: #98cfaa;
+    color: #195532;
+}
+
+.merge-version-help {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-bottom: 15px;
+    color: #5d6d7e;
+    font-size: 12px;
+}
+
+.merge-instructions {
+    margin: 0 0 12px;
+    padding: 10px 12px;
+    background: #fff8e8;
+    border: 1px solid #f3d48a;
+    border-radius: 6px;
+    color: #8a6d1f;
+    font-size: 12px;
+}
+
+#file-merge-chunks {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.merge-inline-preview {
+    margin: 0 0 12px;
+    background: #fbfcfe;
+    border: 1px solid #dfe7f1;
+    border-radius: 6px;
+    padding: 12px;
+    max-height: 220px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    line-height: 1.4;
+}
+
+.merge-inline-context,
+.merge-inline-local,
+.merge-inline-incoming,
+.merge-inline-auto,
+.merge-inline-pending {
+    display: inline;
+}
+
+.merge-inline-local {
+    background: rgba(231, 76, 60, 0.28);
+}
+
+.merge-inline-incoming {
+    background: rgba(46, 204, 113, 0.26);
+}
+
+.merge-inline-auto {
+    background: rgba(52, 152, 219, 0.16);
+}
+
+.merge-inline-pending {
+    background: rgba(243, 156, 18, 0.24);
+    color: #8a5a00;
+    font-style: italic;
+}
+
+.merge-context,
+.merge-auto-content,
+#file-merge-result,
+.merge-variant pre {
+    margin: 0;
+    background: #fbfcfe;
+    border: 1px solid #dfe7f1;
+    border-radius: 6px;
+    padding: 12px;
+    max-height: 260px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.merge-context {
+    background: #f5f7fa;
+}
+
+.merge-chunk {
+    border: 1px solid #d8e0ea;
+    border-radius: 10px;
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(24, 39, 75, 0.04);
+    padding: 14px;
+}
+
+.merge-chunk.active {
+    border-color: #2980b9;
+    box-shadow: 0 0 0 2px rgba(41, 128, 185, 0.12);
+}
+
+.merge-chunk-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+
+.merge-chunk-header .radio-inline {
+    margin: 0;
+    padding-left: 0;
+}
+
+.merge-chunk-header .radio-inline input {
+    margin-right: 5px;
+}
+
+.merge-variants {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 12px;
+}
+
+.merge-variant {
+    border: 1px solid #e3e9ef;
+    border-radius: 8px;
+    background: #fdfefe;
+    padding: 10px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.merge-variant-selectable {
+    cursor: pointer;
+}
+
+.merge-variant.selected {
+    border-color: #2980b9;
+    box-shadow: 0 0 0 2px rgba(41, 128, 185, 0.12);
+}
+
+.merge-variant-base {
+    background: #f7f7f7;
+}
+
+.merge-variant-local pre {
+    background: rgba(231, 76, 60, 0.16);
+    border-color: rgba(231, 76, 60, 0.28);
+}
+
+.merge-variant-incoming pre {
+    background: rgba(46, 204, 113, 0.16);
+    border-color: rgba(46, 204, 113, 0.28);
+}
+
+.merge-variant-base pre {
+    background: #f3f4f6;
+    border-color: #d7dde5;
+}
+
+.merge-variant-title {
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: #34495e;
+}
+
+.merge-result-panel {
+    margin-top: 18px;
+    border-top: 1px solid #e6edf5;
+    padding-top: 16px;
+}
+
+.merge-result-panel h4 {
+    margin-top: 0;
+    margin-bottom: 10px;
+}
+
+#file-merge-result {
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    line-height: 1.4;
+    margin: 0;
+}
+
+.merge-preview-context,
+.merge-preview-choice {
+    display: inline;
+}
+
+.merge-preview-choice {
+    border-radius: 4px;
+    transition: background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.merge-preview-choice.merge-preview-local {
+    background: rgba(231, 76, 60, 0.28);
+}
+
+.merge-preview-choice.merge-preview-incoming {
+    background: rgba(46, 204, 113, 0.26);
+}
+
+.merge-preview-choice.merge-preview-auto {
+    background: rgba(52, 152, 219, 0.16);
+}
+
+.merge-preview-choice.merge-preview-pending {
+    background: rgba(243, 156, 18, 0.24);
+    color: #8a5a00;
+    font-style: italic;
+}
+
+.merge-preview-choice.active {
+    background: rgba(41, 128, 185, 0.20);
+    box-shadow: 0 0 0 2px rgba(41, 128, 185, 0.18);
+}
+
+@media (max-width: 991px) {
+    #file-preview-modal .modal-dialog {
+        width: auto;
+        margin: 10px;
+    }
 }

--- a/views/css/coreupdater.css
+++ b/views/css/coreupdater.css
@@ -104,9 +104,9 @@
     background: #f8f8f8;
     padding: 10px;
 }
-#file-preview-diff .diff-add { background-color: #e6ffed; }
-#file-preview-diff .diff-del { background-color: #ffeef0; }
-#file-preview-diff .diff-hunk { background-color: #f1f8ff; }
+#file-preview-diff .diff-add { background-color: #c8f7cf; }
+#file-preview-diff .diff-del { background-color: #ffd2d7; }
+#file-preview-diff .diff-hunk { background-color: #e0ecff; }
 
 .ignore-label {
     font-weight: normal !important;

--- a/views/js/controller.js
+++ b/views/js/controller.js
@@ -174,11 +174,14 @@ window.initializeCoreUpdater = function(translations) {
     incrementProcess('UPDATE', process, endProgress);
   };
 
-  var update = function(compareProcessId, ignored) {
+  var update = function(compareProcessId, ignored, mergedFiles) {
     initProgress(translations.UPDATE, translations.UPDATE_DESCRIPTION);
     var params = { compareProcessId: compareProcessId };
     if (ignored && ignored.length > 0) {
       params.ignoreFiles = ignored;
+    }
+    if (mergedFiles) {
+      params.mergedFiles = JSON.stringify(mergedFiles);
     }
     executeAction('INIT_UPDATE', params)
         .then(runUpdate)
@@ -293,4 +296,3 @@ window.initializeCoreUpdater = function(translations) {
     preview: preview,
   }
 };
-

--- a/views/js/controller.js
+++ b/views/js/controller.js
@@ -174,11 +174,19 @@ window.initializeCoreUpdater = function(translations) {
     incrementProcess('UPDATE', process, endProgress);
   };
 
-  var update = function(compareProcessId) {
+  var update = function(compareProcessId, ignored) {
     initProgress(translations.UPDATE, translations.UPDATE_DESCRIPTION);
-    executeAction('INIT_UPDATE', { compareProcessId: compareProcessId })
+    var params = { compareProcessId: compareProcessId };
+    if (ignored && ignored.length > 0) {
+      params.ignoreFiles = ignored;
+    }
+    executeAction('INIT_UPDATE', params)
         .then(runUpdate)
         .catch(displayError);
+  };
+
+  var preview = function(compareProcessId, file) {
+    return executeAction('PREVIEW_FILE', { compareProcessId: compareProcessId, file: file });
   };
 
   var checkDatabase = function() {
@@ -282,6 +290,7 @@ window.initializeCoreUpdater = function(translations) {
     compare: compare,
     update: update,
     checkDatabase: checkDatabase,
+    preview: preview,
   }
 };
 

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -64,22 +64,24 @@
     {/if}
   {/if}
 
-
   {if $edits}
     <div class="alert alert-warning">
       <h2>{l s='You have local changes!' mod='coreupdater'}</h2>
       <p>
         {l s='Oh, bummer. Some of thirty bees core files have been [1]modified[/1]. That makes it a little bit harder to update your store.' tags=['<b>'] mod='coreupdater'}
       </p>
+      <p>
+        {l s='Use [1]Review & merge[/1] on modified files to compare the original file, the local version, and the new version before you update.' tags=['<b>'] mod='coreupdater'}
+      </p>
       {if $developerMode}
-      <p>{l s='You are using Developer mode and few functions are visible. Use them at your own risk and only if you know what they do.' mod='coreupdater'}</p>
+        <p>{l s='You are using Developer mode and additional preview / ignore tools are visible. Use them at your own risk and only if you know what they do.' mod='coreupdater'}</p>
       {/if}
       <p>
         {l s='Modification of core files is not recommended. It makes it very hard to keep your store updated.' tags=['<b>'] mod='coreupdater'}
         {l s='You should [1]extract[/1] your modifications to overrides or to module. If unsure how to do that, please contact [2]thirty bees support[/2], we can help.' tags=['<b>', '<a href="https://thirtybees.com/contact/" target="_blank">'] mod='coreupdater'}
       </p>
       <p>
-        {l s='Please note that by updating your store, your local modifications [1]will be overwritten[/1].' tags=['<b>'] mod='coreupdater'}
+        {l s='Please note that by updating your store, your local modifications [1]will be overwritten[/1] unless you explicitly keep them.' tags=['<b>'] mod='coreupdater'}
         {l s='Core updater will [1]backup[/1] all those files before update, though.' tags=['<b>'] mod='coreupdater'}
       </p>
     </div>
@@ -109,63 +111,81 @@
   {/if}
 
   {if $changeSet['change']}
-    <p>
+    <div class="file-section">
       <h4>{l s='Changed files' mod='coreupdater'}</h4>
-      <ul class="file-list">
-        {foreach from=$changeSet['change'] key='file' item='modified'}
-          <li>
-            <code>{$file|escape:'html'}</code>
-            {if $modified}
-              <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
+      <p class="file-section-note">
+        {l s='These files differ from the target version. Review local customizations before you update.' mod='coreupdater'}
+      </p>
+    </div>
+    <ul class="file-list">
+      {foreach from=$changeSet['change'] key='file' item='modified'}
+        <li>
+          <code>{$file|escape:'html'}</code>
+          {if $modified}
+            <span class="badge badge-warning">{l s='local customization' mod='coreupdater'}</span>
+            {if !empty($previewableFiles[$file])}
+              <a href="#" class="btn btn-default btn-xs review-file" data-file="{$file|escape:'html'}">{l s='Review & merge' mod='coreupdater'}</a>
+              <span class="badge badge-info merge-state" data-file="{$file|escape:'html'}" style="display:none;">{l s='Merged' mod='coreupdater'}</span>
             {/if}
-            {if $developerMode}
-              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
-              <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore file' mod='coreupdater'}</label>
-            {/if}
-          </li>
-        {/foreach}
-      </ul>
-    </p>
+          {elseif $developerMode && !empty($previewableFiles[$file])}
+            <a href="#" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Review' mod='coreupdater'}</a>
+          {/if}
+          {if $developerMode}
+            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Skip this file in this update' mod='coreupdater'}</label>
+          {/if}
+        </li>
+      {/foreach}
+    </ul>
   {/if}
 
   {if $changeSet['add']}
-    <p>
+    <div class="file-section">
       <h4>{l s='Missing files' mod='coreupdater'}</h4>
-      <ul class="file-list">
-        {foreach from=$changeSet['add'] key='file' item='modified'}
-          <li>
-            <code>{$file|escape:'html'}</code>
-            {if $modified}
-              <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
-            {/if}
-            {if $developerMode}
-              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
-              <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore file' mod='coreupdater'}</label>
-            {/if}
-          </li>
-        {/foreach}
-      </ul>
-    </p>
+      <p class="file-section-note">
+        {l s='These files exist in the new core version but are currently missing from your shop.' mod='coreupdater'}
+      </p>
+    </div>
+    <ul class="file-list">
+      {foreach from=$changeSet['add'] key='file' item='modified'}
+        <li>
+          <code>{$file|escape:'html'}</code>
+          {if $modified}
+            <span class="badge badge-warning">{l s='local customization' mod='coreupdater'}</span>
+          {/if}
+          {if $developerMode && !empty($previewableFiles[$file])}
+            <a href="#" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Review' mod='coreupdater'}</a>
+          {/if}
+          {if $developerMode}
+            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Skip this file in this update' mod='coreupdater'}</label>
+          {/if}
+        </li>
+      {/foreach}
+    </ul>
   {/if}
 
   {if $changeSet['remove']}
-    <p>
+    <div class="file-section">
       <h4>{l s='Extra files' mod='coreupdater'}</h4>
-      <ul class="file-list">
-        {foreach from=$changeSet['remove'] key='file' item='modified'}
-          <li>
-            <code>{$file|escape:'html'}</code>
-            {if $modified}
-              <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
-            {/if}
-            {if $developerMode}
-              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
-              <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore file' mod='coreupdater'}</label>
-            {/if}
-          </li>
-        {/foreach}
-      </ul>
-    </p>
+      <p class="file-section-note">
+        {l s='These files are present in your shop but do not exist in the version you are updating to.' mod='coreupdater'}
+      </p>
+    </div>
+    <ul class="file-list">
+      {foreach from=$changeSet['remove'] key='file' item='modified'}
+        <li>
+          <code>{$file|escape:'html'}</code>
+          {if $modified}
+            <span class="badge badge-warning">{l s='local customization' mod='coreupdater'}</span>
+          {/if}
+          {if $developerMode && !empty($previewableFiles[$file])}
+            <a href="#" class="btn btn-default btn-xs preview-file" data-file="{$file|escape:'html'}">{l s='Review' mod='coreupdater'}</a>
+          {/if}
+          {if $developerMode}
+            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Keep this file during this update' mod='coreupdater'}</label>
+          {/if}
+        </li>
+      {/foreach}
+    </ul>
   {/if}
 
   {if $edits || $changes}
@@ -178,57 +198,505 @@
   {/if}
 </div>
 
-{if $developerMode}
 <div id="file-preview-modal" class="modal fade" tabindex="-1">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">{l s='File preview' mod='coreupdater'}</h4>
+        <h4 class="modal-title" id="file-preview-title">{l s='File review' mod='coreupdater'}</h4>
+        <p class="merge-file-path" id="file-preview-path"></p>
       </div>
       <div class="modal-body">
-        <pre id="file-preview-diff" class="diff-content"></pre>
+        <div id="file-preview-diff-container">
+          <pre id="file-preview-diff" class="diff-content"></pre>
+        </div>
+        <div id="file-merge-container" style="display:none;">
+          <div class="alert alert-info" id="file-merge-summary"></div>
+          <div class="merge-toolbar">
+            <button type="button" class="btn btn-default btn-sm" id="merge-select-local">{l s='Keep local version everywhere' mod='coreupdater'}</button>
+            <button type="button" class="btn btn-default btn-sm" id="merge-select-incoming">{l s='Use new version everywhere' mod='coreupdater'}</button>
+          </div>
+          <div class="merge-instructions">
+            {l s='For each highlighted change, click either the Local version card or the New version card. Save is enabled only after every change has a selection.' mod='coreupdater'}
+          </div>
+          <div class="merge-version-help">
+            <span><strong>{l s='Local version' mod='coreupdater'}</strong> {l s='is the file currently in the shop, including merchant customizations.' mod='coreupdater'}</span>
+            <span><strong>{l s='New version' mod='coreupdater'}</strong> {l s='is the file from the update target you are installing.' mod='coreupdater'}</span>
+            <span><strong>{l s='Installed core version' mod='coreupdater'}</strong> {l s='is the official file for the currently installed core revision, before local customizations.' mod='coreupdater'}</span>
+          </div>
+          <div id="file-merge-chunks"></div>
+          <div class="merge-result-panel">
+            <h4>{l s='Merged file preview' mod='coreupdater'}</h4>
+            <pre id="file-merge-result"></pre>
+          </div>
+        </div>
       </div>
       <div class="modal-footer">
+        <button type="button" id="file-merge-save" class="btn btn-primary" style="display:none;">{l s='Save merge for update' mod='coreupdater'}</button>
         <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Close' mod='coreupdater'}</button>
       </div>
-  </div>
+    </div>
   </div>
 </div>
-{/if}
 
 <script type="application/javascript">
-  var compareProcessId = "{$compareProcessId}";
-  {if $developerMode}
-  {literal}
-  var escapeHtml = function(str) {
-    return str.replace(/[&<>]/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;'}[c]; });
+  var compareProcessId = "{$compareProcessId|escape:'javascript'}";
+  var mergeTexts = {
+    localVersion: "{l s='Local version' mod='coreupdater'|escape:'javascript'}",
+    incomingVersion: "{l s='New version' mod='coreupdater'|escape:'javascript'}",
+    installedCoreVersion: "{l s='Installed core version' mod='coreupdater'|escape:'javascript'}",
+    localOnly: "{l s='Local customization only' mod='coreupdater'|escape:'javascript'}",
+    incomingOnly: "{l s='Core update only' mod='coreupdater'|escape:'javascript'}",
+    conflict: "{l s='Both changed' mod='coreupdater'|escape:'javascript'}",
+    autoMerged: "{l s='Auto-merged' mod='coreupdater'|escape:'javascript'}",
+    chooseVersion: "{l s='Choose Local version or New version below.' mod='coreupdater'|escape:'javascript'}",
+    pendingChoice: "{l s='Selection required' mod='coreupdater'|escape:'javascript'}",
+    mergeSaved: "{l s='Merge saved for this file. It will be written during update.' mod='coreupdater'|escape:'javascript'}",
+    summaryTemplate: "{l s='This file contains [1]%s[/1] selectable change block(s), including [2]%s[/2] conflict(s). Choose the local or new version for each block, then save the merge before updating.' sprintf=['%s','%s'] tags=['<b>','<b>'] mod='coreupdater'|escape:'javascript'}",
+    fallbackSummary: "{l s='Fine-grained merge detection was not available for this file, so the updater is offering a whole-file choice instead.' mod='coreupdater'|escape:'javascript'}",
+    saveDisabled: "{l s='Select Local version or New version for every change before saving this merge.' mod='coreupdater'|escape:'javascript'}",
+    previewTitle: "{l s='File preview' mod='coreupdater'|escape:'javascript'}",
+    reviewTitle: "{l s='Review and merge file' mod='coreupdater'|escape:'javascript'}"
   };
-  $(".preview-file").click(function(e){
-    e.preventDefault();
-    var file = $(this).data('file');
-    coreUpdater.preview(compareProcessId, file).then(function(res){
-      var diff = atob(res.diff || '');
-      var html = diff.split('\n').map(function(line){
-        var cls = '';
-        if (line.startsWith('+')) cls = 'diff-add';
-        else if (line.startsWith('-')) cls = 'diff-del';
-        else if (line.startsWith('@@')) cls = 'diff-hunk';
-        return '<span class="'+cls+'">'+escapeHtml(line)+'</span>';
-      }).join('\n');
-      $('#file-preview-diff').html(html);
-      $('#file-preview-modal').modal('show');
-    }).catch(function(err){
-      alert(err.message || err);
-    });
-  });
-  {/literal}
-  {/if}
+
   {literal}
-  $("#update-button").click(function(){
-    var ignore = [];
-    $('.ignore-file:checked').each(function(){ ignore.push($(this).data('file')); });
-    coreUpdater.update(compareProcessId, ignore);
-  });
+  (function() {
+    var savedMergeSelections = {};
+    var savedMergeFiles = {};
+    var currentPreview = null;
+    var currentPreviewFile = null;
+    var activeChunkId = null;
+    var currentExplicitSelections = {};
+
+    var escapeHtml = function(str) {
+      return (str || '').replace(/[&<>]/g, function(c) {
+        return {'&': '&amp;', '<': '&lt;', '>': '&gt;'}[c];
+      });
+    };
+
+    var decodeBase64 = function(str) {
+      if (!str) {
+        return '';
+      }
+      try {
+        return decodeURIComponent(escape(window.atob(str)));
+      } catch (e) {
+        return window.atob(str);
+      }
+    };
+
+    var encodeBase64 = function(str) {
+      try {
+        return window.btoa(unescape(encodeURIComponent(str)));
+      } catch (e) {
+        return window.btoa(str);
+      }
+    };
+
+    var getSummaryText = function(choiceCount, conflictCount) {
+      return mergeTexts.summaryTemplate
+        .replace('%s', choiceCount)
+        .replace('%s', conflictCount);
+    };
+
+    var getChoiceStateInfo = function(state) {
+      switch (state) {
+        case 'local':
+          return {title: mergeTexts.localOnly, badge: 'badge-warning'};
+        case 'incoming':
+          return {title: mergeTexts.incomingOnly, badge: 'badge-success'};
+        case 'same':
+          return {title: mergeTexts.autoMerged, badge: 'badge-info'};
+        default:
+          return {title: mergeTexts.conflict, badge: 'badge-danger'};
+      }
+    };
+
+    var renderDiff = function(diff) {
+      var lines = diff.split('\n');
+      if (lines.length >= 2 && lines[0].indexOf('--- ') === 0 && lines[1].indexOf('+++ ') === 0) {
+        lines = lines.slice(2);
+      }
+
+      return lines.map(function(line) {
+        var cls = '';
+        if (line.indexOf('+++ ') === 0 || line.indexOf('--- ') === 0 || line.indexOf('@@') === 0) {
+          cls = 'diff-hunk';
+        } else if (line.indexOf('+') === 0) {
+          cls = 'diff-add';
+        } else if (line.indexOf('-') === 0) {
+          cls = 'diff-del';
+        }
+        return '<span class="' + cls + '">' + escapeHtml(line) + '</span>';
+      }).join('\n');
+    };
+
+    var splitPreservingLines = function(content) {
+      if (!content) {
+        return [];
+      }
+      return content.match(/[^\n]*\n|[^\n]+/g) || [];
+    };
+
+    var trimContext = function(content, keepEnd) {
+      var lines = splitPreservingLines(content);
+      var limit = 8;
+      if (lines.length <= limit) {
+        return content;
+      }
+      if (keepEnd) {
+        return "...\n" + lines.slice(lines.length - limit).join('');
+      }
+      return lines.slice(0, limit).join('') + "...\n";
+    };
+
+    var setActiveChunk = function(chunkId) {
+      activeChunkId = chunkId;
+      $('#file-merge-chunks .merge-chunk').removeClass('active');
+      $('#file-merge-chunks .merge-chunk[data-chunk-id="' + chunkId + '"]').addClass('active');
+      $('#file-merge-result .merge-preview-choice').removeClass('active');
+      $('#file-merge-result .merge-preview-choice[data-chunk="' + chunkId + '"]').addClass('active');
+    };
+
+    var getCurrentSelections = function() {
+      return $.extend({}, currentExplicitSelections);
+    };
+
+    var requiresSelection = function(chunk) {
+      return chunk && chunk.type === 'choice' && chunk.state !== 'same';
+    };
+
+    var hasPendingSelections = function(preview, selections) {
+      var pending = false;
+      (preview.chunks || []).forEach(function(chunk) {
+        if (requiresSelection(chunk) && !Object.prototype.hasOwnProperty.call(selections, chunk.id)) {
+          pending = true;
+        }
+      });
+      return pending;
+    };
+
+    var buildMergedContent = function(preview, selections) {
+      var content = '';
+      (preview.chunks || []).forEach(function(chunk) {
+        if (chunk.type === 'context') {
+          content += decodeBase64(chunk.content);
+          return;
+        }
+
+        if (chunk.state === 'same') {
+          content += decodeBase64(chunk.content || chunk.incoming);
+          return;
+        }
+
+        var choice = selections[chunk.id] || chunk.defaultChoice || 'incoming';
+        content += decodeBase64(chunk[choice] || '');
+      });
+
+      var lineEnding = decodeBase64(preview.lineEnding || '');
+      if (lineEnding && lineEnding !== '\n') {
+        content = content.replace(/\n/g, lineEnding);
+      }
+      return content;
+    };
+
+    var syncVariantSelection = function() {
+      $('#file-merge-chunks .merge-variant').removeClass('selected');
+      var selections = getCurrentSelections();
+      $('#file-merge-chunks .merge-chunk').each(function() {
+        var chunkId = $(this).data('chunk-id');
+        if (Object.prototype.hasOwnProperty.call(selections, chunkId)) {
+          $('#file-merge-chunks .merge-variant[data-chunk="' + chunkId + '"][data-choice="' + selections[chunkId] + '"]').addClass('selected');
+        }
+      });
+    };
+
+    var updateMergeResult = function() {
+      if (!currentPreview) {
+        return;
+      }
+      var selections = getCurrentSelections();
+      var html = [];
+      (currentPreview.chunks || []).forEach(function(chunk) {
+        if (chunk.type === 'context') {
+          html.push('<span class="merge-preview-context">' + escapeHtml(decodeBase64(chunk.content)) + '</span>');
+          return;
+        }
+
+        var content = '';
+        var extraClass = '';
+        if (chunk.state === 'same') {
+          content = decodeBase64(chunk.content || chunk.incoming);
+          extraClass = ' merge-preview-auto';
+        } else {
+          if (Object.prototype.hasOwnProperty.call(selections, chunk.id)) {
+            var choice = selections[chunk.id];
+            content = decodeBase64(chunk[choice] || '');
+            extraClass = ' merge-preview-' + choice;
+          } else {
+            content = mergeTexts.pendingChoice;
+            extraClass = ' merge-preview-pending';
+          }
+        }
+
+        html.push(
+          '<span class="merge-preview-choice' + extraClass + (activeChunkId === chunk.id ? ' active' : '') + '" data-chunk="' + chunk.id + '">' +
+          escapeHtml(content) +
+          '</span>'
+        );
+      });
+      $('#file-merge-result').html(html.join(''));
+      syncVariantSelection();
+      if (activeChunkId) {
+        $('#file-merge-result .merge-preview-choice[data-chunk="' + activeChunkId + '"]').addClass('active');
+      }
+      updateMergeSaveState();
+    };
+
+    var updateSavedStateBadge = function(file) {
+      $('.merge-state').each(function() {
+        var $badge = $(this);
+        if ($badge.data('file') === file) {
+          if (savedMergeFiles[file]) {
+            $badge.show();
+          } else {
+            $badge.hide();
+          }
+        }
+      });
+    };
+
+    var refreshMergeBlocks = function() {
+      if (!currentPreview) {
+        return;
+      }
+      var currentActive = activeChunkId;
+      renderMergeChunks(currentPreview, getCurrentSelections());
+      if (currentActive) {
+        setActiveChunk(currentActive);
+      }
+    };
+
+    var renderChunkCodePreview = function(chunk, before, after, selections) {
+      var html = '<pre class="merge-inline-preview">';
+      html += '<span class="merge-inline-context">' + escapeHtml(before) + '</span>';
+
+      if (chunk.state === 'same') {
+        html += '<span class="merge-inline-auto">' + escapeHtml(decodeBase64(chunk.content || chunk.incoming)) + '</span>';
+      } else {
+        if (Object.prototype.hasOwnProperty.call(selections, chunk.id)) {
+          var choice = selections[chunk.id];
+          html += '<span class="merge-inline-' + choice + '">' + escapeHtml(decodeBase64(chunk[choice] || '')) + '</span>';
+        } else {
+          html += '<span class="merge-inline-local">' + escapeHtml(decodeBase64(chunk.local || '')) + '</span>';
+          html += '<span class="merge-inline-incoming">' + escapeHtml(decodeBase64(chunk.incoming || '')) + '</span>';
+        }
+      }
+
+      html += '<span class="merge-inline-context">' + escapeHtml(after) + '</span>';
+      html += '</pre>';
+      return html;
+    };
+
+    var updateMergeSaveState = function() {
+      if (!currentPreview) {
+        $('#file-merge-save').prop('disabled', true).attr('title', '');
+        return;
+      }
+
+      var pending = hasPendingSelections(currentPreview, getCurrentSelections());
+      $('#file-merge-save')
+        .prop('disabled', pending)
+        .attr('title', pending ? mergeTexts.saveDisabled : '');
+    };
+
+    var renderMergeChunks = function(preview, selections) {
+      var html = [];
+      (preview.chunks || []).forEach(function(chunk, index) {
+        if (chunk.type === 'context') {
+          return;
+        }
+
+        var before = '';
+        var after = '';
+        if (index > 0 && preview.chunks[index - 1].type === 'context') {
+          before = trimContext(decodeBase64(preview.chunks[index - 1].content), true);
+        }
+        if (index + 1 < preview.chunks.length && preview.chunks[index + 1].type === 'context') {
+          after = trimContext(decodeBase64(preview.chunks[index + 1].content), false);
+        }
+
+        var info = getChoiceStateInfo(chunk.state);
+        if (chunk.state === 'same') {
+          html.push(
+            '<div class="merge-chunk merge-chunk-auto" data-chunk-id="' + chunk.id + '">' +
+            renderChunkCodePreview(chunk, before, after, selections) +
+            '  <div class="merge-chunk-header">' +
+            '    <span class="badge ' + info.badge + '">' + escapeHtml(info.title) + '</span>' +
+            '  </div>' +
+            '  <pre class="merge-auto-content">' + escapeHtml(decodeBase64(chunk.content || chunk.incoming)) + '</pre>' +
+            '</div>'
+          );
+          return;
+        }
+
+        html.push(
+          '<div class="merge-chunk merge-state-' + chunk.state + '" data-chunk-id="' + chunk.id + '">' +
+          renderChunkCodePreview(chunk, before, after, selections) +
+          '  <div class="merge-chunk-header">' +
+          '    <span class="badge ' + info.badge + '">' + escapeHtml(info.title) + '</span>' +
+          '  </div>' +
+          '  <div class="merge-variants">' +
+          '    <div class="merge-variant merge-variant-selectable merge-variant-local" data-chunk="' + chunk.id + '" data-choice="local">' +
+          '      <div class="merge-variant-title">' + escapeHtml(mergeTexts.localVersion) + '</div>' +
+          '      <pre>' + escapeHtml(decodeBase64(chunk.local)) + '</pre>' +
+          '    </div>' +
+          '    <div class="merge-variant merge-variant-selectable merge-variant-incoming" data-chunk="' + chunk.id + '" data-choice="incoming">' +
+          '      <div class="merge-variant-title">' + escapeHtml(mergeTexts.incomingVersion) + '</div>' +
+          '      <pre>' + escapeHtml(decodeBase64(chunk.incoming)) + '</pre>' +
+          '    </div>' +
+          '    <div class="merge-variant merge-variant-base" data-chunk="' + chunk.id + '" data-choice="base">' +
+          '      <div class="merge-variant-title">' + escapeHtml(mergeTexts.installedCoreVersion) + '</div>' +
+          '      <pre>' + escapeHtml(decodeBase64(chunk.base)) + '</pre>' +
+          '    </div>' +
+          '  </div>' +
+          '</div>'
+        );
+      });
+      $('#file-merge-chunks').html(html.join(''));
+      $('#file-merge-chunks .merge-chunk').on('click', function(e) {
+        setActiveChunk($(this).data('chunk-id'));
+      });
+      $('#file-merge-chunks .merge-variant').on('click', function() {
+        var chunkId = $(this).data('chunk');
+        var choice = $(this).data('choice');
+        setActiveChunk(chunkId);
+        if (choice === 'local' || choice === 'incoming') {
+          currentExplicitSelections[chunkId] = choice;
+          activeChunkId = chunkId;
+          refreshMergeBlocks();
+          updateMergeResult();
+        } else {
+          refreshMergeBlocks();
+          updateMergeResult();
+        }
+      });
+      $('#file-merge-result').off('click.mergePreview').on('click.mergePreview', '.merge-preview-choice', function() {
+        setActiveChunk($(this).data('chunk'));
+      });
+      syncVariantSelection();
+    };
+
+    var openDiffPreview = function(file, response) {
+      currentPreview = null;
+      currentPreviewFile = file;
+      $('#file-preview-title').text(mergeTexts.previewTitle);
+      $('#file-preview-path').text(file);
+      $('#file-preview-diff-container').show();
+      $('#file-merge-container').hide();
+      $('#file-merge-save').hide();
+      $('#file-preview-diff').html(renderDiff(decodeBase64(response.diff || '')));
+      $('#file-preview-modal').modal('show');
+    };
+
+    var openMergePreview = function(file, response) {
+      currentPreview = response;
+      currentPreviewFile = file;
+      currentExplicitSelections = $.extend({}, savedMergeSelections[file] || {});
+      $('#file-preview-title').text(mergeTexts.reviewTitle);
+      $('#file-preview-path').text(file);
+      $('#file-preview-diff-container').hide();
+      $('#file-merge-container').show();
+      $('#file-merge-save').show();
+      $('#file-merge-summary').removeClass('alert-success').addClass('alert-info');
+      $('#file-merge-summary').html(
+        (response.fallback ? '<p>' + escapeHtml(mergeTexts.fallbackSummary) + '</p>' : '') +
+        getSummaryText(response.choiceCount || 0, response.conflictCount || 0)
+      );
+      renderMergeChunks(response, savedMergeSelections[file] || {});
+      activeChunkId = null;
+      if (response.chunks && response.chunks.length) {
+        response.chunks.some(function(chunk) {
+          if (chunk.type === 'choice') {
+            activeChunkId = chunk.id;
+            return true;
+          }
+          return false;
+        });
+      }
+      updateMergeResult();
+      if (activeChunkId) {
+        setActiveChunk(activeChunkId);
+      }
+      updateMergeSaveState();
+      $('#file-preview-modal').modal('show');
+    };
+
+    var openFilePreview = function(file) {
+      coreUpdater.preview(compareProcessId, file).then(function(response) {
+        if (response.mode === 'merge') {
+          openMergePreview(file, response);
+        } else {
+          openDiffPreview(file, response);
+        }
+      }).catch(function(err) {
+        var message = err && err.message ? err.message : err;
+        if (err && err.details) {
+          message += '\n\n' + err.details;
+        }
+        alert(message);
+      });
+    };
+
+    var applyChoiceToAll = function(choice) {
+      $('#file-merge-chunks .merge-variant[data-choice="' + choice + '"]').each(function() {
+        currentExplicitSelections[$(this).data('chunk')] = choice;
+      });
+      refreshMergeBlocks();
+      updateMergeResult();
+    };
+
+    $('.review-file, .preview-file').on('click', function(e) {
+      e.preventDefault();
+      openFilePreview($(this).data('file'));
+    });
+
+    $('#merge-select-local').on('click', function() {
+      applyChoiceToAll('local');
+    });
+
+    $('#merge-select-incoming').on('click', function() {
+      applyChoiceToAll('incoming');
+    });
+
+    $('#file-merge-save').on('click', function() {
+      if (!currentPreview || !currentPreviewFile) {
+        return;
+      }
+      var selections = getCurrentSelections();
+      savedMergeSelections[currentPreviewFile] = selections;
+      savedMergeFiles[currentPreviewFile] = encodeBase64(buildMergedContent(currentPreview, selections));
+      updateSavedStateBadge(currentPreviewFile);
+      $('#file-merge-summary').removeClass('alert-info').addClass('alert-success').html(escapeHtml(mergeTexts.mergeSaved));
+      $('#file-preview-modal').modal('hide');
+    });
+
+    $('#update-button').on('click', function() {
+      var ignored = [];
+      var mergedFiles = {};
+
+      $('.ignore-file:checked').each(function() {
+        ignored.push($(this).data('file'));
+      });
+
+      $.each(savedMergeFiles, function(file, content) {
+        if (ignored.indexOf(file) === -1) {
+          mergedFiles[file] = content;
+        }
+      });
+
+      coreUpdater.update(compareProcessId, ignored, mergedFiles);
+    });
+  })();
   {/literal}
 </script>

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -71,6 +71,9 @@
       <p>
         {l s='Oh, bummer. Some of thirty bees core files have been [1]modified[/1]. That makes it a little bit harder to update your store.' tags=['<b>'] mod='coreupdater'}
       </p>
+      {if $developerMode}
+      <p>{l s='You are using Developer mode and few functions are visible. Use them at your own risk and only if you know what they do.' mod='coreupdater'}</p>
+      {/if}
       <p>
         {l s='Modification of core files is not recommended. It makes it very hard to keep your store updated.' tags=['<b>'] mod='coreupdater'}
         {l s='You should [1]extract[/1] your modifications to overrides or to module. If unsure how to do that, please contact [2]thirty bees support[/2], we can help.' tags=['<b>', '<a href="https://thirtybees.com/contact/" target="_blank">'] mod='coreupdater'}

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -189,25 +189,15 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Close' mod='coreupdater'}</button>
       </div>
-    </div>
+  </div>
   </div>
 </div>
-<style>
-  #file-preview-diff {
-    max-height: 70vh;
-    overflow:auto;
-    background:#f8f8f8;
-    padding:10px;
-  }
-  #file-preview-diff .diff-add {background-color:#e6ffed;}
-  #file-preview-diff .diff-del {background-color:#ffeef0;}
-  #file-preview-diff .diff-hunk {background-color:#f1f8ff;}
-</style>
 {/if}
 
 <script type="application/javascript">
   var compareProcessId = "{$compareProcessId}";
   {if $developerMode}
+  {literal}
   var escapeHtml = function(str) {
     return str.replace(/[&<>]/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;'}[c]; });
   };
@@ -229,10 +219,13 @@
       alert(err.message || err);
     });
   });
+  {/literal}
   {/if}
+  {literal}
   $("#update-button").click(function(){
     var ignore = [];
     $('.ignore-file:checked').each(function(){ ignore.push($(this).data('file')); });
     coreUpdater.update(compareProcessId, ignore);
   });
+  {/literal}
 </script>

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -115,8 +115,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
-            <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
-            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
+            {if $developerMode}
+              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+              <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore file' mod='coreupdater'}</label>
+            {/if}
           </li>
         {/foreach}
       </ul>
@@ -133,8 +135,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
-            <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
-            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
+            {if $developerMode}
+              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+              <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore file' mod='coreupdater'}</label>
+            {/if}
           </li>
         {/foreach}
       </ul>
@@ -151,8 +155,10 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
-            <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
-            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
+            {if $developerMode}
+              <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+              <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore file' mod='coreupdater'}</label>
+            {/if}
           </li>
         {/foreach}
       </ul>
@@ -169,6 +175,7 @@
   {/if}
 </div>
 
+{if $developerMode}
 <div id="file-preview-modal" class="modal fade" tabindex="-1">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
@@ -177,16 +184,7 @@
         <h4 class="modal-title">{l s='File preview' mod='coreupdater'}</h4>
       </div>
       <div class="modal-body">
-        <div class="row">
-          <div class="col-sm-6">
-            <h4>{l s='Current file' mod='coreupdater'}</h4>
-            <pre id="file-preview-local"></pre>
-          </div>
-          <div class="col-sm-6">
-            <h4>{l s='New file' mod='coreupdater'}</h4>
-            <pre id="file-preview-remote"></pre>
-          </div>
-        </div>
+        <pre id="file-preview-diff" class="diff-content"></pre>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Close' mod='coreupdater'}</button>
@@ -194,20 +192,44 @@
     </div>
   </div>
 </div>
+<style>
+  #file-preview-diff {
+    max-height: 70vh;
+    overflow:auto;
+    background:#f8f8f8;
+    padding:10px;
+  }
+  #file-preview-diff .diff-add {background-color:#e6ffed;}
+  #file-preview-diff .diff-del {background-color:#ffeef0;}
+  #file-preview-diff .diff-hunk {background-color:#f1f8ff;}
+</style>
+{/if}
 
 <script type="application/javascript">
   var compareProcessId = "{$compareProcessId}";
+  {if $developerMode}
+  var escapeHtml = function(str) {
+    return str.replace(/[&<>]/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;'}[c]; });
+  };
   $(".preview-file").click(function(e){
     e.preventDefault();
     var file = $(this).data('file');
     coreUpdater.preview(compareProcessId, file).then(function(res){
-      $('#file-preview-local').text(res.local);
-      $('#file-preview-remote').text(res.remote);
+      var diff = atob(res.diff || '');
+      var html = diff.split('\n').map(function(line){
+        var cls = '';
+        if (line.startsWith('+')) cls = 'diff-add';
+        else if (line.startsWith('-')) cls = 'diff-del';
+        else if (line.startsWith('@@')) cls = 'diff-hunk';
+        return '<span class="'+cls+'">'+escapeHtml(line)+'</span>';
+      }).join('\n');
+      $('#file-preview-diff').html(html);
       $('#file-preview-modal').modal('show');
     }).catch(function(err){
       alert(err.message || err);
     });
   });
+  {/if}
   $("#update-button").click(function(){
     var ignore = [];
     $('.ignore-file:checked').each(function(){ ignore.push($(this).data('file')); });

--- a/views/templates/admin/result.tpl
+++ b/views/templates/admin/result.tpl
@@ -115,6 +115,8 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
           </li>
         {/foreach}
       </ul>
@@ -131,6 +133,8 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
           </li>
         {/foreach}
       </ul>
@@ -147,6 +151,8 @@
             {if $modified}
               <span class="badge badge-warning">{l s='modified' mod='coreupdater'}</span>
             {/if}
+            <a href="#" class="preview-file" data-file="{$file|escape:'html'}">{l s='Preview' mod='coreupdater'}</a>
+            <label class="ignore-label"><input type="checkbox" class="ignore-file" data-file="{$file|escape:'html'}"> {l s='Ignore' mod='coreupdater'}</label>
           </li>
         {/foreach}
       </ul>
@@ -160,10 +166,51 @@
         {l s='Update store' mod='coreupdater'}
       </button>
     </div>
-    <script type="application/javascript">
-      $("#update-button").click(function() {
-        coreUpdater.update("{$compareProcessId}");
-      });
-    </script>
   {/if}
 </div>
+
+<div id="file-preview-modal" class="modal fade" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">{l s='File preview' mod='coreupdater'}</h4>
+      </div>
+      <div class="modal-body">
+        <div class="row">
+          <div class="col-sm-6">
+            <h4>{l s='Current file' mod='coreupdater'}</h4>
+            <pre id="file-preview-local"></pre>
+          </div>
+          <div class="col-sm-6">
+            <h4>{l s='New file' mod='coreupdater'}</h4>
+            <pre id="file-preview-remote"></pre>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Close' mod='coreupdater'}</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="application/javascript">
+  var compareProcessId = "{$compareProcessId}";
+  $(".preview-file").click(function(e){
+    e.preventDefault();
+    var file = $(this).data('file');
+    coreUpdater.preview(compareProcessId, file).then(function(res){
+      $('#file-preview-local').text(res.local);
+      $('#file-preview-remote').text(res.remote);
+      $('#file-preview-modal').modal('show');
+    }).catch(function(err){
+      alert(err.message || err);
+    });
+  });
+  $("#update-button").click(function(){
+    var ignore = [];
+    $('.ignore-file:checked').each(function(){ ignore.push($(this).data('file')); });
+    coreUpdater.update(compareProcessId, ignore);
+  });
+</script>


### PR DESCRIPTION
- Added a new PREVIEW_FILE action and logic for excluding user-selected files from updates, enabling merchants to skip specific files during the update process
- Expanded the client-side updater to send ignored file paths and fetch preview data from the server for on-demand comparison
- Enhanced the update results template with preview links, ignore checkboxes, and a modal showing current vs. new file contents before applying updates
- New function is only visible with module's developer mode ON. A new warning is displayed.

Usefull if merchant/developer has knowledge of which local files were changed (during testing, debugging) but wants to easily introduce new updates in other files.

<img width="1004" height="609" alt="image" src="https://github.com/user-attachments/assets/c3a7442e-cb64-4ec6-bad7-05eb002a2ecf" />

<img width="1195" height="922" alt="image" src="https://github.com/user-attachments/assets/388f7362-b064-4249-9c6b-d49bea104a30" />
<img width="1159" height="912" alt="image" src="https://github.com/user-attachments/assets/a3ea5c17-426f-4492-831e-c51ccc715d4c" />
